### PR TITLE
Fixed default port in json-read.

### DIFF
--- a/klio/json.scm
+++ b/klio/json.scm
@@ -54,7 +54,7 @@
 ;;;
 
 
-(define (json-read #!optional (port (current-output-port)))
+(define (json-read #!optional (port (current-input-port)))
 
   (define lookahead (peek-char port))
 


### PR DESCRIPTION
In `json.scm`, the default port for json-read is current-output-port:
```scheme
(define (json-read #!optional (port (current-output-port)))
```
I tested it in Gambit REPL, it works well, since gsi opened an input-output port for REPL. But when I test it in a script, I got an error:
```
*** ERROR IN json#json-read, "json.scm"@59.21 -- (Argument 1) Character INPUT PORT expected
(peek-char '#<output-port #2 (stdout)>)
```
So it should be a strictly input port.